### PR TITLE
Make class compatible with PluginManager

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,12 +3,6 @@ name: IncompatibleAPIPluginLoader
 main: Sandertv\IncompatibleApiPluginLoader\IncompatibleApiPluginLoader
 version: 0.1.0
 api:
-- 3.0.0-ALPHA1
-- 3.0.0-ALPHA2
-- 3.0.0-ALPHA3
-- 3.0.0-ALPHA4
-- 3.0.0-ALPHA5
-- 3.0.0-ALPHA6
 - 3.0.0-ALPHA7
 author: Sandertv
 description: Allows enabling all plugins, disregarding the API version of it.

--- a/src/Sandertv/IncompatibleApiPluginLoader/IncompatibleApiPluginManager.php
+++ b/src/Sandertv/IncompatibleApiPluginLoader/IncompatibleApiPluginManager.php
@@ -31,7 +31,7 @@ class IncompatibleApiPluginManager extends PluginManager {
 	 *
 	 * @return Plugin[]
 	 */
-	public function loadPlugins($directory, $newLoaders = null){
+	public function loadPlugins(string $directory, array $newLoaders = null){
 		if(is_dir($directory)){
 			$plugins = [];
 			$loadedPlugins = [];


### PR DESCRIPTION
Fixes error message "Declaration of Sandertv\IncompatibleApiPluginLoader\IncompatibleApiPluginManager::loadPlugins($directory, $newLoaders = NULL) should be compatible with pocketmine\plugin\PluginManager::loadPlugins(string $directory, array $newLoaders = NULL)" (EXCEPTION) in "IncompatibleAPIPluginLoader.phar/src/Sandertv/IncompatibleApiPluginLoader/IncompatibleApiPluginManager"